### PR TITLE
Model customer as class, not struct

### DIFF
--- a/ChattyIO/docs/ChattyIO.md
+++ b/ChattyIO/docs/ChattyIO.md
@@ -162,10 +162,10 @@ added, the I/O overhead can quickly accumulate.
 
 ```C#
 [Serializable]
-public struct Customer
+public class Customer
 {
-    public int Id;
-    public string Name;
+    public int Id { get; set; }
+    public string Name { get; set; }
     ...
 }
 ...
@@ -438,10 +438,10 @@ to reduce fragmentation of the file on disk.
 **C#**
 ```C#
 [Serializable]
-public struct Customer
+public class Customer
 {
-    public int Id;
-    public string Name;
+    public int Id { get; set; }
+    public string Name { get; set; }
     ...
 }
 ...


### PR DESCRIPTION
The docs for ChattyIO include a code sample that models a `Customer` as a `struct` with public fields.  This goes against [best practices](https://msdn.microsoft.com/en-us/library/ms229017.aspx).

Switching to model as a `class` with properties.